### PR TITLE
Add Lees-Edwards boundary conditions and tests

### DIFF
--- a/examples/lees_edwards_brownian.py
+++ b/examples/lees_edwards_brownian.py
@@ -1,0 +1,54 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Brownian dynamics example with Lees-Edwards boundaries."""
+
+from absl import app
+
+from jax import random
+import jax.numpy as jnp
+
+from jax_md import space, energy, simulate, partition, util
+
+
+def main(_):
+  key = random.PRNGKey(0)
+
+  N = 32
+  side = jnp.array([10.0, 10.0, 10.0])
+  shear_rate = 0.1
+  displacement, shift = space.lees_edwards(side, shear_rate)
+
+  neighbor_fn = partition.lees_edwards_neighbor_list(
+      displacement, side, shear_rate, 2.5, dr_threshold=0.3)
+
+  key, split = random.split(key)
+  R = random.uniform(split, (N, 3), minval=0.0, maxval=side, dtype=util.f32)
+
+  energy_fn = energy.soft_sphere_pair(displacement)
+  dt = 1e-3
+  init_fn, apply_fn = simulate.brownian(energy_fn, shift, dt, kT=1.0)
+  state = init_fn(key, R)
+  nbrs = neighbor_fn.allocate(state.position, t=0.0)
+
+  for step in range(10):
+    t = step * dt
+    nbrs = neighbor_fn.update(state.position, nbrs, t=t)
+    state = apply_fn(state, neighbor_idx=nbrs.idx, t=t)
+
+  print(state.position)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -626,6 +626,7 @@ class NeighborList:
   update_fn: Callable[[Array, 'NeighborList'],
                       'NeighborList'] = dataclasses.static_field()
 
+
   def update(self, position: Array, **kwargs) -> 'NeighborList':
     return self.update_fn(position, self, **kwargs)
 
@@ -641,6 +642,29 @@ class NeighborList:
   @property
   def malformed_box(self) -> bool:
     return self.error.code & PEC.MALFORMED_BOX
+
+
+@dataclasses.dataclass
+class LeesEdwardsNeighborList:
+  """Wrapper carrying shear offset for Lees-Edwards neighbor lists."""
+  inner: NeighborList
+  shear_shift: float
+
+  @property
+  def idx(self):
+    return self.inner.idx
+
+  @property
+  def reference_position(self):
+    return self.inner.reference_position
+
+  @property
+  def did_buffer_overflow(self) -> bool:
+    return self.inner.did_buffer_overflow
+
+  @property
+  def cell_size(self):
+    return self.inner.cell_size
 
 
 @dataclasses.dataclass
@@ -987,6 +1011,36 @@ def neighbor_list(displacement_or_metric: DisplacementOrMetricFn,
 
   return NeighborListFns(allocate_fn, update_fn)  # pytype: disable=wrong-arg-count
 
+
+def lees_edwards_neighbor_list(displacement: DisplacementOrMetricFn,
+                               box: Box,
+                               shear_rate: float,
+                               r_cutoff: float,
+                               dr_threshold: float = 0.0,
+                               format: NeighborListFormat =
+                               NeighborListFormat.Dense,
+                               **static_kwargs) -> NeighborListFns:
+  """Neighbor list that triggers rebuilds from cumulative shear offset."""
+  nl_fn = neighbor_list(displacement, box, r_cutoff, dr_threshold,
+                         format=format, **static_kwargs)
+  Lz = float(box[2])
+
+  def allocate(position: Array, t: float = 0.0, **kwargs):
+    nbrs = nl_fn.allocate(position, t=t, **kwargs)
+    shear_shift = 0.5 * shear_rate * Lz * float(t)
+    return LeesEdwardsNeighborList(nbrs, shear_shift)
+
+  def update(position: Array, nbrs: LeesEdwardsNeighborList,
+             t: float = 0.0, **kwargs):
+    shear_shift = 0.5 * shear_rate * Lz * float(t)
+    if abs(shear_shift - nbrs.shear_shift) >= float(nbrs.cell_size):
+      new_nbrs = nl_fn.allocate(position, t=t, **kwargs)
+      return LeesEdwardsNeighborList(new_nbrs, shear_shift)
+    else:
+      new_nbrs = nl_fn.update(position, nbrs.inner, t=t, **kwargs)
+      return LeesEdwardsNeighborList(new_nbrs, nbrs.shear_shift)
+
+  return NeighborListFns(allocate, update)
 
 def neighbor_list_mask(neighbor: NeighborList, mask_self: bool = False
                        ) -> Array:

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -416,6 +416,70 @@ def periodic_general(box: Box,
   return displacement_fn, shift_fn
 
 
+def lees_edwards(side: Box, shear_rate: float, wrapped: bool = True) -> Space:
+  """Lees-Edwards shear periodic boundary conditions.
+
+  Implements sliding periodic boundaries with shear in the x direction and
+  gradient in the z direction. The system size should be specified by a vector
+  ``side = [Lx, Ly, Lz]``. The displacement and shift functions accept a
+  keyword argument ``t`` denoting the current simulation time.
+
+  Args:
+    side: A vector specifying the size of the simulation box in each
+      dimension. Only three dimensional systems are currently supported.
+    shear_rate: The shear rate :math:`\dot{\gamma}`.
+    wrapped: If ``True`` particles are wrapped back into the box after
+      applying a shift.
+
+  Returns:
+    ``(displacement_fn, shift_fn)`` implementing Lees-Edwards boundaries.
+  """
+  side = jnp.asarray(side)
+  if side.shape[-1] != 3:
+    raise ValueError('lees_edwards only supports 3D boxes.')
+
+  Lx, Ly, Lz = side
+
+  def displacement_fn(Ra: Array, Rb: Array, t: float = 0.0,
+                      **unused_kwargs) -> Array:
+    dR = pairwise_displacement(Ra, Rb)
+    dx = dR[..., 0]
+    dy = dR[..., 1]
+    dz = dR[..., 2]
+
+    n = jnp.round(dz / Lz)
+    dz = dz - Lz * n
+    dx = dx - shear_rate * t * Lz * n
+
+    dx = jnp.mod(dx + Lx * f32(0.5), Lx) - Lx * f32(0.5)
+    dy = jnp.mod(dy + Ly * f32(0.5), Ly) - Ly * f32(0.5)
+
+    return jnp.stack((dx, dy, dz), axis=-1)
+
+  if wrapped:
+    def shift_fn(R: Array, dR: Array, t: float = 0.0,
+                 **unused_kwargs) -> Array:
+      R = R + dR
+      x = R[..., 0]
+      y = R[..., 1]
+      z = R[..., 2]
+
+      n = jnp.floor(z / Lz)
+      z = z - Lz * n
+      x = x - shear_rate * t * Lz * n
+
+      x = jnp.mod(x, Lx)
+      y = jnp.mod(y, Ly)
+
+      return jnp.stack((x, y, z), axis=-1)
+  else:
+    def shift_fn(R: Array, dR: Array, t: float = 0.0,
+                 **unused_kwargs) -> Array:
+      return R + dR
+
+  return displacement_fn, shift_fn
+
+
 def metric(displacement: DisplacementFn) -> MetricFn:
   """Takes a displacement function and creates a metric."""
   return lambda Ra, Rb, **kwargs: distance(displacement(Ra, Rb, **kwargs))

--- a/tests/lees_edwards_test.py
+++ b/tests/lees_edwards_test.py
@@ -1,0 +1,240 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Lees-Edwards boundary conditions."""
+
+from absl.testing import absltest
+
+import jax.numpy as jnp
+
+import os, sys, types, importlib, numpy as onp
+
+jax_md_path = os.path.join(os.path.dirname(__file__), '..', 'jax_md')
+jax_md_pkg = types.ModuleType('jax_md')
+jax_md_pkg.__path__ = [jax_md_path]
+sys.modules['jax_md'] = jax_md_pkg
+
+space = importlib.import_module('jax_md.space')
+partition = importlib.import_module('jax_md.partition')
+util = importlib.import_module('jax_md.util')
+f32 = util.f32
+
+
+class LeesEdwardsTest(absltest.TestCase):
+
+  def test_zero_shear_matches_periodic(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    disp_p, _ = space.periodic(side)
+    disp_le, _ = space.lees_edwards(side, shear_rate=0.0)
+    Ra = jnp.array([1.0, 2.0, 3.0])
+    Rb = jnp.array([4.0, 5.0, 6.0])
+    t = 1.23
+    onp.testing.assert_allclose(disp_p(Ra, Rb), disp_le(Ra, Rb, t=t))
+
+  def test_cross_boundary_displacement(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    gamma_dot = 0.1
+    disp, _ = space.lees_edwards(side, gamma_dot)
+    Ra = jnp.array([1.0, 0.0, 1.0])
+    Rb = jnp.array([2.0, 0.0, 9.0])
+    dR = disp(Ra, Rb, t=1.0)
+    expected = jnp.array([0.0, 0.0, 2.0])
+    onp.testing.assert_allclose(dR, expected)
+
+  def test_large_shear_wraps(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    gamma_dot = 0.1
+    disp, _ = space.lees_edwards(side, gamma_dot)
+    Ra = jnp.array([1.0, 0.0, 1.0])
+    Rb = jnp.array([2.0, 0.0, 9.0])
+    dR0 = disp(Ra, Rb, t=0.0)
+    dR = disp(Ra, Rb, t=20.0)
+    onp.testing.assert_allclose(dR, dR0)
+
+  def test_neighbor_list(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    gamma_dot = 0.2
+    disp, _ = space.lees_edwards(side, gamma_dot)
+    nl_fn = partition.lees_edwards_neighbor_list(
+        disp, side, gamma_dot, 3.0,
+        format=partition.NeighborListFormat.Dense)
+    R = jnp.array([[1.0, 0.0, 1.0],
+                   [2.0, 0.0, 9.0]], dtype=f32)
+    neighbors = nl_fn.allocate(R, t=1.0)
+    self.assertEqual(neighbors.idx[0, 0], 1)
+    self.assertEqual(neighbors.idx[1, 0], 0)
+
+  def test_neighbor_list_zero_shear_matches_periodic(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    disp_p, _ = space.periodic(side)
+    disp_le, _ = space.lees_edwards(side, shear_rate=0.0)
+    nl_p_fn = partition.neighbor_list(disp_p, side, 3.0,
+                                      format=partition.NeighborListFormat.Dense)
+    nl_le_fn = partition.lees_edwards_neighbor_list(
+        disp_le, side, 0.0, 3.0,
+        format=partition.NeighborListFormat.Dense)
+    R = jnp.array([[1.0, 0.0, 1.0],
+                   [2.0, 0.0, 9.0]], dtype=f32)
+    nbrs_p = nl_p_fn.allocate(R)
+    nbrs_le = nl_le_fn.allocate(R, t=1.0)
+    onp.testing.assert_array_equal(nbrs_p.idx, nbrs_le.idx)
+
+  def test_neighbor_list_changes_with_time(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    gamma_dot = 0.5
+    disp, _ = space.lees_edwards(side, gamma_dot)
+    nl_fn = partition.lees_edwards_neighbor_list(
+        disp, side, gamma_dot, 3.0,
+        format=partition.NeighborListFormat.Dense)
+    R = jnp.array([[1.0, 0.0, 1.0],
+                   [1.5, 0.0, 9.0]], dtype=f32)
+    nbrs0 = nl_fn.allocate(R, t=0.0)
+    nbrs = nl_fn.allocate(R, t=5.0)
+    self.assertEqual(nbrs0.idx.shape[1], 1)
+    self.assertEqual(nbrs.idx.shape[1], 0)
+
+  def test_neighbor_list_rebuilds_only_when_needed(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    gamma_dot = 0.3
+    disp, shift = space.lees_edwards(side, gamma_dot)
+    nl_fn = partition.lees_edwards_neighbor_list(
+        disp, side, gamma_dot, 3.0, dr_threshold=0.4,
+        format=partition.NeighborListFormat.Dense)
+
+    R = jnp.array([[1.0, 0.0, 1.0],
+                   [1.5, 0.0, 9.0]], dtype=f32)
+    t = 0.0
+    nbrs = nl_fn.allocate(R, t=t)
+
+    # Displace slightly below the rebuild threshold; neighbor list should not rebuild.
+    dR_small = jnp.array([[0.1, 0.0, 0.0],
+                          [0.0, 0.0, 0.0]], dtype=f32)
+    R_small = shift(R, dR_small, t=t)
+    nbrs_small = nl_fn.update(R_small, nbrs, t=t)
+    # Neighbor list shouldn't rebuild; reference positions remain unchanged.
+    onp.testing.assert_array_equal(nbrs_small.reference_position, nbrs.reference_position)
+    expected_small = nl_fn.allocate(R_small, t=t)
+    onp.testing.assert_array_equal(nbrs_small.idx, expected_small.idx)
+
+    # Move beyond the threshold; neighbor list should rebuild and remain correct.
+    dR_large = jnp.array([[3.0, 0.0, 0.0],
+                          [0.0, 0.0, 0.0]], dtype=f32)
+    R_large = shift(R_small, dR_large, t=t)
+    nbrs_large = nl_fn.update(R_large, nbrs_small, t=t)
+    # Rebuild updates the reference positions to the new configuration.
+    onp.testing.assert_array_equal(nbrs_large.reference_position, R_large)
+    expected_large = nl_fn.allocate(R_large, t=t)
+    onp.testing.assert_array_equal(nbrs_large.idx, expected_large.idx)
+
+  def test_neighbor_list_sequence_correctness(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    gamma_dot = 0.4
+    disp, shift = space.lees_edwards(side, gamma_dot)
+    nl_fn = partition.lees_edwards_neighbor_list(
+        disp, side, gamma_dot, 3.0, dr_threshold=0.4,
+        format=partition.NeighborListFormat.Dense)
+
+    R = jnp.array([[1.0, 0.0, 1.0],
+                   [2.0, 0.0, 1.2],
+                   [8.0, 0.0, 1.0]], dtype=f32)
+
+    t = 0.0
+    nbrs = nl_fn.allocate(R, t=t)
+
+    # Small displacement should not trigger a rebuild.
+    t = 0.5
+    dR_small = jnp.array([[0.1, 0.0, 0.0],
+                          [0.0, 0.0, 0.0],
+                          [0.0, 0.0, 0.0]], dtype=f32)
+    R = shift(R, dR_small, t=t)
+    nbrs_small = nl_fn.update(R, nbrs, t=t)
+    onp.testing.assert_array_equal(nbrs_small.reference_position,
+                                   nbrs.reference_position)
+    expected_small = nl_fn.allocate(R, t=t)
+    onp.testing.assert_array_equal(nbrs_small.idx, expected_small.idx)
+
+    # A larger displacement should rebuild the neighbor list.
+    t = 1.5
+    dR_large = jnp.array([[3.0, 0.0, 0.0],
+                          [0.0, 0.0, 0.0],
+                          [0.0, 0.0, 0.0]], dtype=f32)
+    R = shift(R, dR_large, t=t)
+    nbrs_large = nl_fn.update(R, nbrs_small, t=t)
+    onp.testing.assert_array_equal(nbrs_large.reference_position, R)
+    expected_large = nl_fn.allocate(R, t=t)
+    pad = jnp.full(nbrs_large.idx.shape, R.shape[0], dtype=nbrs_large.idx.dtype)
+    pad = pad.at[:, :expected_large.idx.shape[1]].set(expected_large.idx)
+    onp.testing.assert_array_equal(nbrs_large.idx, pad)
+
+    # Advancing time without motion should keep the neighbor list intact.
+    t = 2.5
+    nbrs_final = nl_fn.update(R, nbrs_large, t=t)
+    onp.testing.assert_array_equal(nbrs_final.reference_position, R)
+    expected_final = nl_fn.allocate(R, t=t)
+    onp.testing.assert_array_equal(nbrs_final.idx, expected_final.idx)
+
+
+  def test_neighbor_list_dynamic_shear_matches_bruteforce(self):
+    side = jnp.array([10.0, 10.0, 10.0])
+    gamma_dot = 0.4
+    disp, shift = space.lees_edwards(side, gamma_dot)
+    nl_fn = partition.lees_edwards_neighbor_list(
+        disp, side, gamma_dot, 3.0, dr_threshold=1.0,
+        format=partition.NeighborListFormat.Dense)
+
+    R = jnp.array([[1.0, 0.0, 1.0],
+                   [1.5, 0.0, 9.0],
+                   [8.0, 8.0, 1.0]], dtype=f32)
+
+    dt = 0.1
+    steps = 50
+    t = 0.0
+    nbrs = nl_fn.allocate(R, t=t)
+    cell_size = float(nbrs.cell_size)
+    last_shift = nbrs.shear_shift
+
+    rebuilds = 0
+    for step in range(1, steps + 1):
+      t = step * dt
+      dR = jnp.stack((gamma_dot * R[:, 2] * dt,
+                      jnp.zeros(R.shape[0]),
+                      jnp.zeros(R.shape[0])), axis=1)
+      R = shift(R, dR, t=t)
+      nbrs_new = nl_fn.update(R, nbrs, t=t)
+
+      shear_shift = 0.5 * gamma_dot * float(side[2]) * t
+      expected_rebuild = abs(shear_shift - last_shift) >= cell_size - 1e-6
+      actual_rebuild = not onp.isclose(nbrs_new.shear_shift, nbrs.shear_shift)
+      self.assertEqual(actual_rebuild, expected_rebuild)
+      if actual_rebuild:
+        last_shift = shear_shift
+        rebuilds += 1
+
+      dists = onp.zeros((R.shape[0], R.shape[0]))
+      for i in range(R.shape[0]):
+        for j in range(R.shape[0]):
+          dists[i, j] = onp.linalg.norm(disp(R[i], R[j], t=t))
+      for i in range(R.shape[0]):
+        expected = set(onp.where((dists[i] < 3.0) &
+                                 (onp.arange(R.shape[0]) != i))[0])
+        actual = set(onp.array(nbrs_new.idx[i])[nbrs_new.idx[i] < R.shape[0]])
+        self.assertTrue(expected.issubset(actual))
+
+      nbrs = nbrs_new
+
+    self.assertEqual(rebuilds, 2)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tests/lees_edwards_test.py
+++ b/tests/lees_edwards_test.py
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """Tests for Lees-Edwards boundary conditions."""
 
 from absl.testing import absltest


### PR DESCRIPTION
## Summary
- add `lees_edwards_neighbor_list` wrapper that rebuilds lists when cumulative shear exceeds a cell width
- expand Lees-Edwards tests to cover multi-step neighbor list updates
- provide a Brownian dynamics example using Lees-Edwards neighbor lists
- simulate continuous shear to ensure neighbor lists rebuild only when needed and always contain brute-force neighbors

## Testing
- `pytest tests/lees_edwards_test.py -q`